### PR TITLE
Readme: add direct link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jordanbray/chess.svg?branch=master)](https://travis-ci.org/jordanbray/chess)
 [![crates.io](https://img.shields.io/crates/v/chess.svg)](https://crates.io/crates/chess)
+[![docs.rs](https://docs.rs/chess/badge.svg)](https://docs.rs/chess)
 
 This library handles the process of move generation within a chess engine or chess UI.
 


### PR DESCRIPTION
Just passing by to see the source code (great library btw!) and didn't find a direct link from the Readme to the docs.